### PR TITLE
Add braze encoding filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,24 +33,38 @@ Braze's liquid is a subset of Shopify's liquid, hence some incompatible features
 #### Added
 
 * #### Filters
-    * [property_accessor][braze/property_accessor]: access value from hash
+
+    * Encoding
+
+        | Filter Name | Example | Notes |
+        | --- | --- | --- |
+        | md5 | `{{"sample" \| md5}}` | |
+        | sha1 | `{{"strings" \| sha1}}` | |
+        | sha2 | `{{"to" \| sha2}}` | This is using SHA-256 |
+        | hmac_sha1 | `{{"be" \| hmac_sha1}}` | |
+        | base64 | `{{"encoded" \| base64}}` | |
         
-        Example:
-        ```
-        {{ hash | property_accessor: 'key' }}
-        ```
+
+    * URL 
+
+        | Filter Name | Example | Notes |
+        | --- | --- | --- |
+        | url_escape | `'{{"hey<>hi" \| url_escape}}'` | ⚠️ this uses `encodeURI` which is slightly different from Braze's implementation |
+        | url_param_escape | `'{{"hey<>hi" \| url_param_escape}}'` | ⚠️ this uses `encodeURIComponent` which is slightly different from Braze's implementation |
+
+    * [Property Accessor][braze/property_accessor]
+
+        | Filter Name | Example | Notes |
+        | --- | --- | --- |
+        | property_accessor | `{{hash \| property_accessor: 'key'}}` | Example hash: `{ 'key' => 'hello' }` | |
         
-    * url_escape
+    * JSON Escape
+
+        | Filter Name | Example | Notes |
+        | --- | --- | --- |
+        | json_escape | `{{'123"456' \| json_escape}}` | ⚠️ this uses `JSON.stringify` which is slightly different from Braze's implementation |
     
-        ⚠️ this uses `encodeURI` which is slightly different from Braze's implementation
-    
-    * url_param_escape
-    
-        ⚠️ this uses `encodeURIComponent` which is slightly different from Braze's implementation
-    
-    * json_escape
-    
-        ⚠️ this uses `JSON.stringify` which is slightly different from Braze's implementation
+        
         
 * #### Tags
     * [abort_message][braze/abort_message]: abort rendering and output an optional message
@@ -141,13 +155,6 @@ Braze's liquid is a subset of Shopify's liquid, hence some incompatible features
         
 #### TBD
 Below Braze supported [filters][braze/filters] are yet to be added:
-
-* #### Encoding filters
-    * md5
-    * sha1
-    * sha2
-    * base64
-    * hmac_sha1
 
 * #### Number formatting filters
     * number_with_delimiter

--- a/src/braze/filters/encoding.ts
+++ b/src/braze/filters/encoding.ts
@@ -1,0 +1,25 @@
+import * as crypto from 'crypto'
+
+export default {
+  'md5': (x: string) => {
+    const hash = crypto.createHash('md5')
+    hash.update(x)
+    return hash.digest('hex')
+  },
+  'sha1': (x: string) => {
+    const hash = crypto.createHash('sha1')
+    hash.update(x)
+    return hash.digest('hex')
+  },
+  'sha2': (x: string) => {
+    const hash = crypto.createHash('sha256')
+    hash.update(x)
+    return hash.digest('hex')
+  },
+  'hmac_sha1': (x: string, secretKey: string) => {
+    const hmac = crypto.createHmac('sha1', secretKey)
+    hmac.update(x)
+    return hmac.digest('hex')
+  },
+  'base64': (x: string) => Buffer.from(x, 'utf8').toString('base64')
+}

--- a/src/braze/filters/index.ts
+++ b/src/braze/filters/index.ts
@@ -1,5 +1,6 @@
 import hash from './hash'
 import json from './json'
 import url from './url'
+import encoding from './encoding'
 
-export default { ...hash, ...json, ...url }
+export default { ...hash, ...json, ...url, ...encoding }

--- a/test/integration/braze/filters/encoding.ts
+++ b/test/integration/braze/filters/encoding.ts
@@ -1,0 +1,23 @@
+import { test } from '../../../stub/render'
+
+describe('braze/filters/encoding', function () {
+  describe('md5', function () {
+    it('should return a md5 encoded string', () => test('{{"hey" | md5}}', '6057f13c496ecf7fd777ceb9e79ae285'))
+  })
+
+  describe('sha1', function () {
+    it('should return a sha1 encoded string', () => test('{{"hey" | sha1}}', '7f550a9f4c44173a37664d938f1355f0f92a47a7'))
+  })
+
+  describe('sha2', function () {
+    it('should return a sha256 encoded string', () => test('{{"hey" | sha2}}', 'fa690b82061edfd2852629aeba8a8977b57e40fcb77d1a7a28b26cba62591204'))
+  })
+
+  describe('hmac_sha1', function () {
+    it('should return a hmac-sha1 encoded string', () => test('{{"hey" | hmac_sha1: "secret_key"}}', '2a3969bed25bfeefb00aca4063eb9590b4df8f0e'))
+  })
+
+  describe('base64', function () {
+    it('should return a base64 encoded string', () => test('{{"blah" | base64}}', 'YmxhaA=='))
+  })
+})


### PR DESCRIPTION
This PR adds the encoding filters as outlined in Braze documentation here and relevant tests: https://www.braze.com/docs/user_guide/personalization_and_dynamic_content/liquid/advanced_filters/#advanced-filters

It uses the nodejs crypto library to implement the filters.

I also updated the readme for clarity 😄 