### PR TITLE
feat: add number format filter and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,21 @@ Braze's liquid is a subset of Shopify's liquid, hence some incompatible features
 
         | Filter Name | Example | Notes |
         | --- | --- | --- |
-        | url_escape | `'{{"hey<>hi" \| url_escape}}'` | ⚠️ this uses `encodeURI` which is slightly different from Braze's implementation |
-        | url_param_escape | `'{{"hey<>hi" \| url_param_escape}}'` | ⚠️ this uses `encodeURIComponent` which is slightly different from Braze's implementation |
+        | url_escape | `{{"hey<>hi" \| url_escape}}` | ⚠️ this uses `encodeURI` which is slightly different from Braze's implementation |
+        | url_param_escape | `{{"hey<>hi" \| url_param_escape}}` | ⚠️ this uses `encodeURIComponent` which is slightly different from Braze's implementation |
 
     * [Property Accessor][braze/property_accessor]
 
         | Filter Name | Example | Notes |
         | --- | --- | --- |
-        | property_accessor | `{{hash \| property_accessor: 'key'}}` | Example hash: `{ 'key' => 'hello' }` | |
+        | property_accessor | `{{hash \| property_accessor: 'key'}}` | Example hash: `{ 'key' => 'hello' }` |
         
+    * Number Formatting
+
+        | Filter Name | Example | Notes |
+        | --- | --- | --- |
+        | number_with_delimiter | `{{123456 \| number_with_delimiter}}` | ⚠️ this uses `toLocaleString` which is slightly different from Braze's implementation |
+
     * JSON Escape
 
         | Filter Name | Example | Notes |
@@ -151,13 +157,6 @@ Braze's liquid is a subset of Shopify's liquid, hence some incompatible features
             }
         
         ⚠️ At time of writing, Braze only support nesting 2 levels of content blocks
-
-        
-#### TBD
-Below Braze supported [filters][braze/filters] are yet to be added:
-
-* #### Number formatting filters
-    * number_with_delimiter
 
 [braze/liquid]: https://www.braze.com/docs/user_guide/personalization_and_dynamic_content/liquid/overview/
 [tutorial]: https://shopify.github.io/liquid/basics/introduction/

--- a/src/braze/filters/index.ts
+++ b/src/braze/filters/index.ts
@@ -2,5 +2,6 @@ import hash from './hash'
 import json from './json'
 import url from './url'
 import encoding from './encoding'
+import number from './number'
 
-export default { ...hash, ...json, ...url, ...encoding }
+export default { ...hash, ...json, ...url, ...encoding, ...number }

--- a/src/braze/filters/number.ts
+++ b/src/braze/filters/number.ts
@@ -1,0 +1,3 @@
+export default {
+  'number_with_delimiter': (x: string) => x.toLocaleString()
+}

--- a/test/integration/braze/filters/number.ts
+++ b/test/integration/braze/filters/number.ts
@@ -1,0 +1,11 @@
+import { test } from '../../../stub/render'
+
+describe('braze/filters/number', function () {
+  describe('number_with_delimiter', function () {
+    it('should return a number formatted with commas', () => test('{{123456 | number_with_delimiter}}', '123,456'))
+    it('should return a number formatted with commas', () => test('{{1234 | number_with_delimiter}}', '1,234'))
+    it('should return a number with no commas', () => test('{{123 | number_with_delimiter}}', '123'))
+    it('should return a float formatted with commas', () => test('{{123456.78 | number_with_delimiter}}', '123,456.78'))
+    it('should return a float with 3 decimal places formatted with commas', () => test('{{123456.789 | number_with_delimiter}}', '123,456.789'))
+  })
+})


### PR DESCRIPTION
This PR adds the number formatting filter `number_with_delimiter` and updates the readme 🙂 