### PR TITLE
Added header parsing with some workarounds needed

### DIFF
--- a/src/braze/tags/connectedContent.ts
+++ b/src/braze/tags/connectedContent.ts
@@ -24,12 +24,14 @@ export default <ITagImplOptions>{
       const headersMatch = options.match(headerRegex)
       if( headersMatch != null ) {
         this.options.headers = JSON.parse(headersMatch[1])
-        console.log(headersMatch[1])
       }
       options.replace(headerRegex, '').split(/\s+:/).forEach((optStr) => {
         if (optStr === '') return
 
         const opts = optStr.split(/\s+/)
+        if( opts[0] === "headers" ) {
+          console.log("Headers JSON malformed. Check your headers value")
+        }
         this.options[opts[0]] = opts.length > 1 ? opts[1] : true;
       })
     }
@@ -65,10 +67,8 @@ export default <ITagImplOptions>{
     if( this.options.headers ) {
       // Add specified headers to the headers
       Object.keys(this.options.headers).forEach( key => {
-        console.log(key)
         headers[key] = this.options.headers[key];
       })
-      console.log(headers)
     }
 
     const rpOption = {

--- a/src/braze/tags/connectedContent.ts
+++ b/src/braze/tags/connectedContent.ts
@@ -3,7 +3,6 @@ import Context from '../../context/context'
 import ITagImplOptions from '../../template/tag/itag-impl-options'
 // @ts-ignore
 import * as rp_ from 'request-promise-cache'
-import { OperationCanceledException } from 'typescript'
 const rp = rp_
 
 const re = new RegExp(`(https?(?:[^\\s\\{\\}]+|\\{\\{.*?\\}\\})+)(\\s+(\\s|.)*)?$`)

--- a/test/integration/braze/tags/connectedContent.ts
+++ b/test/integration/braze/tags/connectedContent.ts
@@ -290,7 +290,7 @@ describe('braze/tags/connected_content', function () {
     })
 
     it('should pull correct header from connected content block', async function() {
-      const src = '{% connected_content http://localhost:8080/headertest :headers { "testHeader": "headerValue" } :method post %}'
+      const src = '{% connected_content http://localhost:8080/headertest :headers { "testHeader": "headerValue" } \n:method post %}'
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('pass')
     })
@@ -302,7 +302,7 @@ describe('braze/tags/connected_content', function () {
     })
 
     it('should pull differently formatted JSON header from multi-line connected content block', async function() {
-      const src = '{% connected_content \nhttp://localhost:8080/headertest \n:body p \n:headers { \n"testHeader" :      "headerValue" \n} \n:content_type application/json \n:method post \n%}'
+      const src = '{% connected_content \nhttp://localhost:8080/headertest \n:body p \n:headers { \n"testHeader" :      "headerValue",\n "someId": 2123  \n} \n:content_type application/json \n:method post \n%}'
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('pass')
     })
@@ -311,6 +311,12 @@ describe('braze/tags/connected_content', function () {
       const src = '{% connected_content http://localhost:8080/noheaders :headers { "User-Agent": "differentAgent", "testHeader": "header :method post %}'
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('pass no headers')
+    })
+
+    it('should handle json headers with attribute tags', async function () {
+      const src = '{% connected_content http://localhost:8080/agent2 :headers { "User-Agent": "{{otherAgent}}", "testHeader": "headerValue" } :method post %}'
+      const html = await liquid.parseAndRender(src, {"otherAgent": "differentAgent"})
+      expect(html).to.equal('pass')
     })
 
     it('should overwrite user-agent header from connected content block', async function () {

--- a/test/integration/braze/tags/connectedContent.ts
+++ b/test/integration/braze/tags/connectedContent.ts
@@ -255,4 +255,32 @@ describe('braze/tags/connected_content', function () {
       expect(html2).to.equal('')
     })
   })
+
+  describe("headers should be pulled correctly", async function() {
+    
+    beforeEach(function () {
+      nock('http://localhost:8080', {
+      reqheaders: {
+        'User-Agent': 'brazejs-client',
+        'testHeader': 'headerValue'
+      }
+    })
+      .get('/headertest')
+      .reply(200, { success: true })
+      .persist()
+    })
+
+    it('should not pull incorrect (already existing) header from connected content block', async function () {
+      const src = '{% connected_content http://localhost:8080/headertest :headers { "User-Agent": "someOtherAgent", "testHeader": "headerValue" } :method post %}'
+      const html = await liquid.parseAndRender(src)
+      expect(html).to.equal('')
+    })
+
+    it('should pull correct header from connected content block', async function() {
+      const src = '{% connected_content http://localhost:8080/headertest :headers { "testHeader": "headerValue" } %}'
+      const html = await liquid.parseAndRender(src)
+      expect(html).to.equal('{ success: true }')
+    })
+    
+  })
 })


### PR DESCRIPTION
Hello,

I notices that this library didn't support the parsing of headers in connected content, so I did my best to implement that functionality. The implementation isn't perfect, and could use some improvements.

~~The String parsing of JSON is troublesome with the regex used to split the connected content arguments (previously `/\s*:/`, now `/\s+:/`). **This is a breaking change**, so please recommend an alternative if you think this is a reasonable use case to not be broken. This change break cases where connected content blocks are formatted without a space between the `:` of the connected content option and the previous option value or URL. The parsing of JSON headers works assuming each JSON field follows the regex update above, allowing no white space between each attribute name and the proceeding `:`.~~

~~An example of a now-broken connected content block (see missing space between the body and the :~~

~~`{% connected_content http://localhost:8080/ :body test=true:method POST %}`~~