### PR TITLE
Added support for JSON body parsing

### DIFF
--- a/src/braze/tags/connectedContent.ts
+++ b/src/braze/tags/connectedContent.ts
@@ -70,10 +70,21 @@ export default <ITagImplOptions>{
       }
     }
 
-    let body
-    if (this.options.body) {
-      body = (await this.liquid.parseAndRender(this.options.body, ctx.getAll())).replace(/(?:\r\n|\r|\n|)/g, '')
+    let body = this.options.body
+    if( this.options.body ) { 
+      if( method.toUpperCase() === "POST" && contentType.toLowerCase().includes("application/json") ) {
+        const jsonBody = {}
+        for( const element of this.options.body.split("&") ) {
+          const bodyElementSplit = new String(element).split("=")
+          jsonBody[bodyElementSplit[0]] = (await this.liquid.parseAndRender(bodyElementSplit[1], ctx.getAll())).replace(/(?:\r\n|\r|\n|)/g, '')
+        }
+        body = JSON.stringify(jsonBody)
+      } else {
+        body = await this.liquid.parseAndRender(this.options.body, ctx.getAll())
+        console.log(body)
+      }
     }
+
     const rpOption = {
       'resolveWithFullResponse': true,
       method,

--- a/src/braze/tags/connectedContent.ts
+++ b/src/braze/tags/connectedContent.ts
@@ -79,9 +79,10 @@ export default <ITagImplOptions>{
           jsonBody[bodyElementSplit[0]] = (await this.liquid.parseAndRender(bodyElementSplit[1], ctx.getAll())).replace(/(?:\r\n|\r|\n|)/g, '')
         }
         body = JSON.stringify(jsonBody)
+        console.log(jsonBody)
+        console.log(body)
       } else {
         body = await this.liquid.parseAndRender(this.options.body, ctx.getAll())
-        console.log(body)
       }
     }
 

--- a/src/braze/tags/connectedContent.ts
+++ b/src/braze/tags/connectedContent.ts
@@ -71,16 +71,14 @@ export default <ITagImplOptions>{
     }
 
     let body = this.options.body
-    if( this.options.body ) { 
-      if( method.toUpperCase() === "POST" && contentType.toLowerCase().includes("application/json") ) {
+    if (this.options.body) {
+      if (method.toUpperCase() === 'POST' && contentType.toLowerCase().includes('application/json')) {
         const jsonBody = {}
-        for( const element of this.options.body.split("&") ) {
-          const bodyElementSplit = new String(element).split("=")
+        for (const element of this.options.body.split('&')) {
+          const bodyElementSplit = element.split('=')
           jsonBody[bodyElementSplit[0]] = (await this.liquid.parseAndRender(bodyElementSplit[1], ctx.getAll())).replace(/(?:\r\n|\r|\n|)/g, '')
         }
         body = JSON.stringify(jsonBody)
-        console.log(jsonBody)
-        console.log(body)
       } else {
         body = await this.liquid.parseAndRender(this.options.body, ctx.getAll())
       }

--- a/test/integration/braze/tags/connectedContent.ts
+++ b/test/integration/braze/tags/connectedContent.ts
@@ -337,6 +337,9 @@ describe('braze/tags/connected_content', function () {
         .reply(200, 'pass')
         .post('/bodytest_multiple', {"body": "content", "body2":"content2"})
         .reply(200, 'pass')
+        // You can't pass nested objects in Braze, but you can pass json strings
+        .post('/bodytest_nested', {"body": "{ \"nest\": \"nestedcontent\" }"})
+        .reply(200, 'pass')
         .persist()
     })
 
@@ -352,9 +355,15 @@ describe('braze/tags/connected_content', function () {
       expect(html).to.equal('pass')
     })
 
-    it("should parse body to json using variables", async function() {
+    it("should parse multiple body fields to json", async function() {
       const src = `{% connected_content http://localhost:8080/bodytest_multiple :method post :content_type application/json :body body={{content}}&body2=content2 } %}`
       const html = await liquid.parseAndRender(src, { content: "content" })
+      expect(html).to.equal('pass')
+    })
+
+    it("should parse a nested body to json using variables", async function() {
+      const src = `{% connected_content http://localhost:8080/bodytest_nested :method post :content_type application/json :body body={{content}} } %}`
+      const html = await liquid.parseAndRender(src, { content: '{ "nest": "nestedcontent" }' })
       expect(html).to.equal('pass')
     })
 

--- a/test/integration/braze/tags/connectedContent.ts
+++ b/test/integration/braze/tags/connectedContent.ts
@@ -325,47 +325,45 @@ describe('braze/tags/connected_content', function () {
     })
   })
 
-  describe('process json body', async function() {
-
+  describe('process json body', async function () {
     beforeEach(function () {
       nock('http://localhost:8080', {
         reqheaders: {
           'User-Agent': 'brazejs-client'
         }
       })
-        .post('/bodytest', {"body":"content"})
+        .post('/bodytest', { body: 'content' })
         .reply(200, 'pass')
-        .post('/bodytest_multiple', {"body": "content", "body2":"content2"})
+        .post('/bodytest_multiple', { body: 'content', body2: 'content2' })
         .reply(200, 'pass')
         // You can't pass nested objects in Braze, but you can pass json strings
-        .post('/bodytest_nested', {"body": "{ \"nest\": \"nestedcontent\" }"})
+        .post('/bodytest_nested', { body: '{ "nest": "nestedcontent" }' })
         .reply(200, 'pass')
         .persist()
     })
 
-    it("should parse body to json", async function() {
+    it('should parse body to json', async function () {
       const src = `{% connected_content http://localhost:8080/bodytest :method post :content_type application/json :body body=content } %}`
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('pass')
     })
 
-    it("should parse body to json using variables", async function() {
+    it('should parse body to json using variables', async function () {
       const src = `{% connected_content http://localhost:8080/bodytest :method post :content_type application/json :body body={{content}} } %}`
-      const html = await liquid.parseAndRender(src, { content: "content" })
+      const html = await liquid.parseAndRender(src, { content: 'content' })
       expect(html).to.equal('pass')
     })
 
-    it("should parse multiple body fields to json", async function() {
+    it('should parse multiple body fields to json', async function () {
       const src = `{% connected_content http://localhost:8080/bodytest_multiple :method post :content_type application/json :body body={{content}}&body2=content2 } %}`
-      const html = await liquid.parseAndRender(src, { content: "content" })
+      const html = await liquid.parseAndRender(src, { content: 'content' })
       expect(html).to.equal('pass')
     })
 
-    it("should parse a nested body to json using variables", async function() {
+    it('should parse a nested body to json using variables', async function () {
       const src = `{% connected_content http://localhost:8080/bodytest_nested :method post :content_type application/json :body body={{content}} } %}`
       const html = await liquid.parseAndRender(src, { content: '{ "nest": "nestedcontent" }' })
       expect(html).to.equal('pass')
     })
-
   })
 })


### PR DESCRIPTION
I noticed that Braze formats `application/json` typed content posts differently.

This change parses `application/json` requests into json. It's a bit odd in terms of format, but it's what Braze does.

### From Braze:

##### Template:
```
{% connected_content https://postman-echo.com/post :method post :body a=b&c=d :content_type application/json :save out %}
{{out}}
```
##### Response:
``` JSON
{
  "args": {},
  "data": {
    "a": "b",
    "c": "d"
  },
  "files": {},
  "form": {},
  "headers": {
    "x-forwarded-proto": "https",
    "x-forwarded-port": "443",
    "host": "postman-echo.com",
    "content-length": "17",
    "accept": "application/json",
    "accept-encoding": "gzip, deflate",
    "user-agent": "rest-client/2.0.1 (linux-gnu x86_64) ruby/2.6.5p114",
    "content-type": "application/json"
  },
  "json": {
    "a": "b",
    "c": "d"
  },
  "url": "https://postman-echo.com/post",
  "__http_status_code__": 200
}
```

Other content types may not be getting processed correctly. I'd make the change, but I'm strapped for time.