### PR TITLE
fix: Fixed some issues with connected_content tags printing on error

### DIFF
--- a/src/braze/tags/connectedContent.ts
+++ b/src/braze/tags/connectedContent.ts
@@ -129,7 +129,7 @@ export default <ITagImplOptions>{
       }
       ctx.environments[this.options.save || 'connected'] = jsonRes
     } catch (error) {
-      return res.body
+      console.error(`Could not parse response body: "${res.body}"`)
     }
   }
 }

--- a/src/braze/tags/connectedContent.ts
+++ b/src/braze/tags/connectedContent.ts
@@ -122,14 +122,24 @@ export default <ITagImplOptions>{
       res = e
     }
 
-    try {
-      const jsonRes = JSON.parse(res.body)
-      if (Object.prototype.toString.call(jsonRes) === '[object Object]') {
+    if( res.statusCode >= 200 && res.statusCode <= 299 ) {
+      try{ 
+        const jsonRes = JSON.parse(res.body)
         jsonRes.__http_status_code__ = res.statusCode
+        console.log(jsonRes)
+        ctx.environments[this.options.save || 'connected'] = jsonRes
+      } catch (error) {
+        // TODO what does Braze do in this situation?
+        // if( res.headers.contentType != undefined && 
+        //            res.headers.contentType.toLowerCase().contains('application/json') ) {
+        //   console.error(`Failed to parse body as JSON: "${res.body}"`)
+        // } else {
+          return res.body
+        // }
       }
-      ctx.environments[this.options.save || 'connected'] = jsonRes
-    } catch (error) {
-      console.error(`Could not parse response body: "${res.body}"`)
+    } else {
+      console.error(`${renderedUrl} responded with ${res.statusCode}:\n` + 
+                    `${res.body}`)
     }
   }
 }

--- a/src/braze/tags/connectedContent.ts
+++ b/src/braze/tags/connectedContent.ts
@@ -122,20 +122,20 @@ export default <ITagImplOptions>{
       res = e
     }
 
-    if( res.statusCode >= 200 && res.statusCode <= 299 ) {
-      try{ 
+    if (res.statusCode >= 200 && res.statusCode <= 299) {
+      try {
         const jsonRes = JSON.parse(res.body)
         jsonRes.__http_status_code__ = res.statusCode
         ctx.environments[this.options.save || 'connected'] = jsonRes
       } catch (error) {
-        if( res.headers["content-type"] != undefined && res.headers["content-type"].includes('json') ) {
+        if (res.headers['content-type'] !== undefined && res.headers['content-type'].includes('json')) {
           console.error(`Failed to parse body as JSON: "${res.body}"`)
         } else {
           return res.body
         }
       }
     } else {
-      console.error(`${renderedUrl} responded with ${res.statusCode}:\n` + 
+      console.error(`${renderedUrl} responded with ${res.statusCode}:\n` +
                     `${res.body}`)
     }
   }

--- a/src/braze/tags/connectedContent.ts
+++ b/src/braze/tags/connectedContent.ts
@@ -126,16 +126,13 @@ export default <ITagImplOptions>{
       try{ 
         const jsonRes = JSON.parse(res.body)
         jsonRes.__http_status_code__ = res.statusCode
-        console.log(jsonRes)
         ctx.environments[this.options.save || 'connected'] = jsonRes
       } catch (error) {
-        // TODO what does Braze do in this situation?
-        // if( res.headers.contentType != undefined && 
-        //            res.headers.contentType.toLowerCase().contains('application/json') ) {
-        //   console.error(`Failed to parse body as JSON: "${res.body}"`)
-        // } else {
+        if( res.headers["content-type"] != undefined && res.headers["content-type"].includes('json') ) {
+          console.error(`Failed to parse body as JSON: "${res.body}"`)
+        } else {
           return res.body
-        // }
+        }
       }
     } else {
       console.error(`${renderedUrl} responded with ${res.statusCode}:\n` + 

--- a/test/integration/braze/tags/connectedContent.ts
+++ b/test/integration/braze/tags/connectedContent.ts
@@ -100,6 +100,20 @@ describe('braze/tags/connected_content', function () {
     return expect(html).to.equal('This is not JSON')
   })
 
+  it('should not print or capture result if json is expected in header but invalid json is found', async function () {
+    nock('http://localhost:8080', {
+      reqheaders: {
+        'User-Agent': 'brazejs-client'
+      }
+    })
+      .get('/shouldbejsonbutisnt')
+      .reply(200, "{ bad: json", { "Content-Type": "application/json" })
+
+    const src = '{% connected_content http://localhost:8080/shouldbejsonbutisnt :save user %}{{connected}}'
+    const html = await liquid.parseAndRender(src)
+    return expect(html).to.equal('')
+  })
+
   it('should add status code to result if returning JSON w/ 200', async function () {
     nock('http://localhost:8080', {
       reqheaders: {

--- a/test/integration/braze/tags/connectedContent.ts
+++ b/test/integration/braze/tags/connectedContent.ts
@@ -375,12 +375,12 @@ describe('braze/tags/connected_content', function () {
         }
       })
         .post('/bodytest', { body: 'content' })
-        .reply(200, 'pass')
+        .reply(200, { res: 'pass' })
         .post('/bodytest_multiple', { body: 'content', body2: 'content2' })
-        .reply(200, 'pass')
+        .reply(200, { res: 'pass' })
         // You can't pass nested objects in Braze, but you can pass json strings
         .post('/bodytest_nested', { body: '{ "nest": "nestedcontent" }' })
-        .reply(200, 'pass')
+        .reply(200, { res: 'pass' })
         .persist()
     })
 

--- a/test/integration/braze/tags/connectedContent.ts
+++ b/test/integration/braze/tags/connectedContent.ts
@@ -79,7 +79,7 @@ describe('braze/tags/connected_content', function () {
       }
     })
       .get('/500')
-      .reply(500, { a: 'b' }, { "Content-Type": "application/json" })
+      .reply(500, { a: 'b' }, { 'Content-Type': 'application/json' })
 
     const src = '{% connected_content http://localhost:8080/500 :save user %}{{user.__http_status_code__}}'
     const html = await liquid.parseAndRender(src)
@@ -93,7 +93,7 @@ describe('braze/tags/connected_content', function () {
       }
     })
       .get('/notjson')
-      .reply(200, "This is not JSON")
+      .reply(200, 'This is not JSON')
 
     const src = '{% connected_content http://localhost:8080/notjson :save user %}{{user.__http_status_code__}}'
     const html = await liquid.parseAndRender(src)
@@ -107,7 +107,7 @@ describe('braze/tags/connected_content', function () {
       }
     })
       .get('/shouldbejsonbutisnt')
-      .reply(200, "{ bad: json", { "Content-Type": "application/json" })
+      .reply(200, '{ bad: json', { 'Content-Type': 'application/json' })
 
     const src = '{% connected_content http://localhost:8080/shouldbejsonbutisnt :save user %}{{connected}}'
     const html = await liquid.parseAndRender(src)
@@ -121,7 +121,7 @@ describe('braze/tags/connected_content', function () {
       }
     })
       .get('/200withjson')
-      .reply(200, { a: 'b' }, { "Content-Type": "application/json" })
+      .reply(200, { a: 'b' }, { 'Content-Type': 'application/json' })
 
     const src = '{% connected_content http://localhost:8080/200withjson :save user %}{{user.__http_status_code__}}'
     const html = await liquid.parseAndRender(src)

--- a/test/integration/braze/tags/connectedContent.ts
+++ b/test/integration/braze/tags/connectedContent.ts
@@ -385,25 +385,25 @@ describe('braze/tags/connected_content', function () {
     })
 
     it('should parse body to json', async function () {
-      const src = `{% connected_content http://localhost:8080/bodytest :method post :content_type application/json :body body=content } %}`
+      const src = `{% connected_content http://localhost:8080/bodytest :method post :content_type application/json :body body=content } %}{{connected.res}}`
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('pass')
     })
 
     it('should parse body to json using variables', async function () {
-      const src = `{% connected_content http://localhost:8080/bodytest :method post :content_type application/json :body body={{content}} } %}`
+      const src = `{% connected_content http://localhost:8080/bodytest :method post :content_type application/json :body body={{content}} } %}{{connected.res}}`
       const html = await liquid.parseAndRender(src, { content: 'content' })
       expect(html).to.equal('pass')
     })
 
     it('should parse multiple body fields to json', async function () {
-      const src = `{% connected_content http://localhost:8080/bodytest_multiple :method post :content_type application/json :body body={{content}}&body2=content2 } %}`
+      const src = `{% connected_content http://localhost:8080/bodytest_multiple :method post :content_type application/json :body body={{content}}&body2=content2 } %}{{connected.res}}`
       const html = await liquid.parseAndRender(src, { content: 'content' })
       expect(html).to.equal('pass')
     })
 
     it('should parse a nested body to json using variables', async function () {
-      const src = `{% connected_content http://localhost:8080/bodytest_nested :method post :content_type application/json :body body={{content}} } %}`
+      const src = `{% connected_content http://localhost:8080/bodytest_nested :method post :content_type application/json :body body={{content}} } %}{{connected.res}}`
       const html = await liquid.parseAndRender(src, { content: '{ "nest": "nestedcontent" }' })
       expect(html).to.equal('pass')
     })

--- a/test/integration/braze/tags/connectedContent.ts
+++ b/test/integration/braze/tags/connectedContent.ts
@@ -65,9 +65,9 @@ describe('braze/tags/connected_content', function () {
       }
     })
       .get('/text')
-      .reply(200, 'text response')
+      .reply(200, { res: 'text response' })
 
-    const src = '{% connected_content http://localhost:8080/text %}'
+    const src = '{% connected_content http://localhost:8080/text %}{{connected.res}}'
     const html = await liquid.parseAndRender(src)
     return expect(html).to.equal('text response')
   })
@@ -109,9 +109,9 @@ describe('braze/tags/connected_content', function () {
       })
         .get('/auth')
         .basicAuth({ user: 'username', pass: 'password' })
-        .reply(200, 'auth successful')
+        .reply(200, { res: 'auth successful' })
 
-      const src = '{% connected_content http://localhost:8080/auth :basic_auth secrets %}'
+      const src = '{% connected_content http://localhost:8080/auth :basic_auth secrets %}{{connected.res}}'
       const html = await liquid.parseAndRender(src, {
         __secrets: {
           secrets: {
@@ -167,9 +167,9 @@ describe('braze/tags/connected_content', function () {
       }
     })
       .post('/post', 'a=b&c=d')
-      .reply(201, 'ok')
+      .reply(201, { res: 'ok' })
 
-    const src = '{% connected_content http://localhost:8080/post :method post :body a=b&c=d %}'
+    const src = '{% connected_content http://localhost:8080/post :method post :body a=b&c=d %}{{connected.res}}'
     const html = await liquid.parseAndRender(src)
     return expect(html).to.equal('ok')
   })
@@ -182,9 +182,9 @@ describe('braze/tags/connected_content', function () {
       }
     })
       .get('/plain')
-      .reply(200, 'plain text response')
+      .reply(200, { res: 'plain text response' })
 
-    const src = '{% connected_content http://localhost:8080/plain :content_type text/plain %}'
+    const src = '{% connected_content http://localhost:8080/plain :content_type text/plain %}{{connected.res}}'
     const html = await liquid.parseAndRender(src)
     return expect(html).to.equal('plain text response')
   })
@@ -199,9 +199,9 @@ describe('braze/tags/connected_content', function () {
         }
       })
         .get('/cache')
-        .reply(200, 'cached response')
+        .reply(200, { res: 'cached response' })
         .post('/cache', 'a=b')
-        .reply(201, 'cached response')
+        .reply(201, { res: 'cached response' })
     })
 
     afterEach(function () {
@@ -209,7 +209,7 @@ describe('braze/tags/connected_content', function () {
     })
 
     it('should cache for 5 mins by default', async function () {
-      const src = '{% connected_content http://localhost:8080/cache %}'
+      const src = '{% connected_content http://localhost:8080/cache %}{{connected.res}}'
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('cached response')
 
@@ -223,7 +223,7 @@ describe('braze/tags/connected_content', function () {
     })
 
     it('should not cache for non GET request', async function () {
-      const src = '{% connected_content http://localhost:8080/cache :method post :body a=b %}'
+      const src = '{% connected_content http://localhost:8080/cache :method post :body a=b %}{{connected.res}}'
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('cached response')
 
@@ -232,7 +232,7 @@ describe('braze/tags/connected_content', function () {
     })
 
     it('should cache for specified period', async function () {
-      const src = '{% connected_content http://localhost:8080/cache :cache 100 %}'
+      const src = '{% connected_content http://localhost:8080/cache :cache 100 %}{{connected.res}}'
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('cached response')
 
@@ -246,7 +246,7 @@ describe('braze/tags/connected_content', function () {
     })
 
     it('should not cache if set to 0', async function () {
-      const src = '{% connected_content http://localhost:8080/cache :cache 0 %}'
+      const src = '{% connected_content http://localhost:8080/cache :cache 0 %}{{connected.res}}'
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('cached response')
 
@@ -265,7 +265,7 @@ describe('braze/tags/connected_content', function () {
         }
       })
         .post('/headertest')
-        .reply(200, 'pass')
+        .reply(200, { res: 'pass' })
         .persist()
 
       nock('http://localhost:8080', {
@@ -275,7 +275,7 @@ describe('braze/tags/connected_content', function () {
         }
       })
         .post('/agent2')
-        .reply(200, 'pass')
+        .reply(200, { res: 'pass' })
         .persist()
 
       nock('http://localhost:8080', {
@@ -284,43 +284,85 @@ describe('braze/tags/connected_content', function () {
         }
       })
         .post('/noheaders')
-        .reply(200, 'pass no headers')
+        .reply(200, { res: 'pass no headers' })
         .persist()
     })
 
     it('should pull correct header from connected content block', async function () {
-      const src = '{% connected_content http://localhost:8080/headertest :headers { "testHeader": "headerValue" } \n:method post %}'
+      const src = '{% connected_content http://localhost:8080/headertest :headers { "testHeader": "headerValue" } \n:method post %}{{connected.res}}'
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('pass')
     })
 
     it('should pull correct header from multi-line connected content block', async function () {
-      const src = '{% connected_content \nhttp://localhost:8080/headertest \n:headers { \n"testHeader": "headerValue" \n} \n:content_type application/json \n:method post \n%}'
+      const src = '{% connected_content \nhttp://localhost:8080/headertest \n:headers { \n"testHeader": "headerValue" \n} \n:content_type application/json \n:method post \n%}{{connected.res}}'
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('pass')
     })
 
     it('should pull differently formatted JSON header from multi-line connected content block', async function () {
-      const src = '{% connected_content \nhttp://localhost:8080/headertest \n:headers { \n"testHeader" :      "headerValue",\n "someId": 2123  \n} \n:content_type application/json \n:method post \n%}'
+      const src = '{% connected_content \nhttp://localhost:8080/headertest \n:headers { \n"testHeader" :      "headerValue",\n "someId": 2123  \n} \n:content_type application/json \n:method post \n%}{{connected.res}}'
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('pass')
     })
 
     it('should handle malformed json headers', async function () {
-      const src = '{% connected_content http://localhost:8080/noheaders :headers { "User-Agent": "differentAgent", "testHeader": "header :method post %}'
+      const src = '{% connected_content http://localhost:8080/noheaders :headers { "User-Agent": "differentAgent", "testHeader": "header :method post %}{{connected.res}}'
       const html = await liquid.parseAndRender(src)
       expect(html).to.equal('pass no headers')
     })
 
     it('should handle json headers with attribute tags', async function () {
-      const src = '{% connected_content http://localhost:8080/agent2 :headers { "User-Agent": "{{otherAgent}}", "testHeader": "headerValue" } :method post %}'
+      const src = '{% connected_content http://localhost:8080/agent2 :headers { "User-Agent": "{{otherAgent}}", "testHeader": "headerValue" } :method post %}{{connected.res}}'
       const html = await liquid.parseAndRender(src, { 'otherAgent': 'differentAgent' })
       expect(html).to.equal('pass')
     })
 
     it('should overwrite user-agent header from connected content block', async function () {
-      const src = '{% connected_content http://localhost:8080/agent2 :headers { "User-Agent": "differentAgent", "testHeader": "headerValue" } :method post %}'
+      const src = '{% connected_content http://localhost:8080/agent2 :headers { "User-Agent": "differentAgent", "testHeader": "headerValue" } :method post %}{{connected.res}}'
       const html = await liquid.parseAndRender(src)
+      expect(html).to.equal('pass')
+    })
+  })
+
+  describe('process json body', async function () {
+    beforeEach(function () {
+      nock('http://localhost:8080', {
+        reqheaders: {
+          'User-Agent': 'brazejs-client'
+        }
+      })
+        .post('/bodytest', { body: 'content' })
+        .reply(200, { res: 'pass' })
+        .post('/bodytest_multiple', { body: 'content', body2: 'content2' })
+        .reply(200, { res: 'pass' })
+        // You can't pass nested objects in Braze, but you can pass json strings
+        .post('/bodytest_nested', { body: '{ "nest": "nestedcontent" }' })
+        .reply(200, { res: 'pass' })
+        .persist()
+    })
+
+    it('should parse body to json', async function () {
+      const src = `{% connected_content http://localhost:8080/bodytest :method post :content_type application/json :body body=content } %}{{connected.res}}`
+      const html = await liquid.parseAndRender(src)
+      expect(html).to.equal('pass')
+    })
+
+    it('should parse body to json using variables', async function () {
+      const src = `{% connected_content http://localhost:8080/bodytest :method post :content_type application/json :body body={{content}} } %}{{connected.res}}`
+      const html = await liquid.parseAndRender(src, { content: 'content' })
+      expect(html).to.equal('pass')
+    })
+
+    it('should parse multiple body fields to json', async function () {
+      const src = `{% connected_content http://localhost:8080/bodytest_multiple :method post :content_type application/json :body body={{content}}&body2=content2 } %}{{connected.res}}`
+      const html = await liquid.parseAndRender(src, { content: 'content' })
+      expect(html).to.equal('pass')
+    })
+
+    it('should parse a nested body to json using variables', async function () {
+      const src = `{% connected_content http://localhost:8080/bodytest_nested :method post :content_type application/json :body body={{content}} } %}{{connected.res}}`
+      const html = await liquid.parseAndRender(src, { content: '{ "nest": "nestedcontent" }' })
       expect(html).to.equal('pass')
     })
   })


### PR DESCRIPTION
It looks like `connected_content` tags are printing their contents without explicitly printing them. [This test](https://github.com/yq314/brazejs/blob/master/test/integration/braze/tags/connectedContent.ts#L234) should not be passing, as well as many others in that integration test suite. See: 

```
const src = '{% connected_content http://localhost:8080/cache :cache 100 %}'
const html = await liquid.parseAndRender(src)
expect(html).to.equal('cached response')
```

and it should be:
```diff
- const src = '{% connected_content http://localhost:8080/cache :cache 100 %}'
+ const src = '{% connected_content http://localhost:8080/cache :cache 100 :save res %}{{res}}'
const html = await liquid.parseAndRender(src)
expect(html).to.equal('cached response')
```

I updated all the tests performing like this, and removed the return statement causing the bug.